### PR TITLE
Fix subscription relation error in Venue model

### DIFF
--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -87,6 +87,8 @@ model Venue {
   // Relations
   ownerId           String
   owner             User                @relation(fields: [ownerId], references: [id], onDelete: Cascade)
+  subscriptionId    String?
+  subscription      Subscription?       @relation(fields: [subscriptionId], references: [id], onDelete: SetNull)
   bookings          Booking[]
   analytics         Analytics[]
   bookingWidgets    BookingWidget[]
@@ -483,6 +485,7 @@ model Subscription {
   // Relations
   userId   String
   user     User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  venues   Venue[]
   payments Payment[]
 
   @@map("subscriptions")


### PR DESCRIPTION
## Problem
The Netlify deployment was failing with a TypeScript error: `'subscription' does not exist in type 'VenueSelect'`. The code in `app/api/admin/venues/route.ts` was trying to select `subscription.plan` and `subscription.status` from the Venue model, but this relation didn't exist in the Prisma schema.

## Solution
Added the missing subscription relation to the Venue model:

### Changes Made:
1. **Added `subscriptionId` field** to the Venue model as an optional foreign key
2. **Added `subscription` relation** to the Venue model pointing to the Subscription model
3. **Added `venues` relation** to the Subscription model for reverse lookup
4. **Used `onDelete: SetNull`** for the subscription relation to handle cases where subscriptions are deleted

### Technical Details:
- The relation allows venues to optionally have a subscription
- The API code can now successfully select `subscription.plan` and `subscription.status`
- No migration files needed as Netlify runs `prisma db push` on deploy
- Maintains data integrity with proper foreign key constraints

### Files Changed:
- `app/prisma/schema.prisma` - Added subscription relation to Venue model and venues relation to Subscription model

This fix resolves the Netlify deployment error and allows the admin venues API to function correctly.