### PR TITLE
Fix venue.phone null safety error in booking confirmation

### DIFF
--- a/app/app/api/bookings/route.ts
+++ b/app/app/api/bookings/route.ts
@@ -239,7 +239,7 @@ export async function POST(request: NextRequest) {
       customerName: bookingData.customerName,
       venueName: venue.name,
       venueAddress: `${venue.address}, ${venue.city}`,
-      venuePhone: venue.phone,
+      venuePhone: venue.phone ?? '',
       date: bookingDate.toDateString(),
       time: bookingData.time,
       partySize: bookingData.partySize,


### PR DESCRIPTION
## Problem
The Netlify deployment was failing with a TypeScript error at `./app/api/bookings/route.ts:242:7` where `venue.phone` (which can be null) was being assigned to the `venuePhone` field that expects a string.

## Solution
Changed `venuePhone: venue.phone,` to `venuePhone: venue.phone ?? '',` to handle the case where `venue.phone` is null by providing an empty string as a fallback.

## Changes
- Fixed null safety issue in `app/app/api/bookings/route.ts` line 242
- Used nullish coalescing operator (`??`) to provide empty string fallback for null venue phone numbers

This resolves the TypeScript compilation error and allows the Netlify deployment to proceed successfully.