### PR TITLE
Fix: Remove obsolete services field causing Netlify build failure

### DIFF
--- a/app/app/api/venues/[id]/route.ts
+++ b/app/app/api/venues/[id]/route.ts
@@ -19,7 +19,6 @@ export async function GET(
       where: { id },
       include: {
         tables: true,
-        services: true,
         availability: true,
         _count: {
           select: {


### PR DESCRIPTION
## Problem
Netlify build was failing with the error:
```
./app/api/venues/[id]/route.ts
Type error: Type '{ tables: true; services: true; availability: true; _count: { select: { bookings: true; }; }; }' is not assignable to type 'VenueInclude | null | undefined'.
  Object literal may only specify known properties, and 'services' does not exist in type 'VenueInclude'.
```

## Root Cause
The issue was in the file `app/app/api/venues/[id]/route.ts` (note the double "app" directory structure). The Prisma query on line 22 was trying to include a `services` field that doesn't exist in the current database schema.

## Solution
- Removed the `services: true` line from the Prisma include statement in the GET method
- This was the correct file that Netlify builds from, not the backup version that was previously fixed

## Files Changed
- `app/app/api/venues/[id]/route.ts` - Removed obsolete `services: true` from Prisma include

## Testing
This fix removes the TypeScript error that was preventing Netlify builds from completing successfully. The venue API will continue to work normally without trying to include the non-existent services relation.