### PR TITLE
Fix: Include Prisma CLI & use npx prisma generate

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -8,13 +8,18 @@
   },
   "scripts": {
     "dev": "next dev",
-    "build": "cp .env.build .env.local && prisma generate && next build && rm -f .env.local",
+    "build": "cp .env.build .env.local && npx prisma generate && next build && rm -f .env.local",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "postinstall": "npx prisma generate"
   },
   "dependencies": {
+    "@prisma/client": "^5.22.0",
     "next": "15.1.3",
     "react": "18.3.1",
     "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "prisma": "^5.22.0"
   }
 }


### PR DESCRIPTION
## Problem
The build was failing with exit code 127 because the `prisma` command was not found during the build process. The build script was trying to run `prisma generate` but the Prisma CLI was not installed as a dependency.

## Solution
This PR fixes the Prisma CLI issue by:

### 1. Added Missing Dependencies
- **`prisma`**: Added to `devDependencies` (v5.22.0) - provides the CLI for build-time operations
- **`@prisma/client`**: Added to `dependencies` (v5.22.0) - provides the runtime client for the application

### 2. Updated Build Script
- Changed from `prisma generate` to `npx prisma generate` for better reliability
- This ensures the command works even if prisma isn't globally installed

### 3. Added Postinstall Hook
- Added `"postinstall": "npx prisma generate"` script
- Ensures Prisma client is generated automatically after npm install
- Provides fallback for deployment environments

## Changes Made
- Updated `app/package.json`:
  - Added `@prisma/client` to dependencies
  - Added `prisma` to devDependencies  
  - Modified build script to use `npx prisma generate`
  - Added postinstall script for automatic client generation

## Testing
This should resolve the build failure and allow successful deployment. The Prisma client will be properly generated during the build process.

## Deployment Impact
- ✅ Fixes the current build failure (exit code 127)
- ✅ Ensures Prisma client generation works in Netlify deployment
- ✅ Maintains compatibility with existing Prisma schema and migrations
- ✅ No breaking changes to application functionality