### PR TITLE
Fix TypeScript module error by removing unused test-opening-hours page

### DIFF
--- a/app/app/test-opening-hours/page.tsx
+++ b/app/app/test-opening-hours/page.tsx
@@ -1,1 +1,0 @@
-// Updated file content with opening hours format conversion


### PR DESCRIPTION
## Problem
The `app/app/test-opening-hours/page.tsx` file was causing TypeScript compilation errors during the Next.js build process. The file contained only a comment and no proper module exports, making it invalid as a Next.js page component.

## Solution
Removed the unused test file that was causing the build to fail. The file only contained:
```
// Updated file content with opening hours format conversion
```

This was not a valid Next.js page component and appears to be leftover test code.

## Impact
- ✅ Fixes TypeScript compilation errors
- ✅ Removes unused test code
- ✅ No functional impact on the application